### PR TITLE
Add player role spinner web app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vòng quay Role</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="step1" class="step">
+    <h2>Chọn số người chơi</h2>
+    <select id="playerCount"></select>
+    <button id="startNames">Tiếp tục</button>
+  </div>
+
+  <div id="step2" class="step hidden">
+    <h2>Nhập tên người chơi</h2>
+    <form id="nameForm"></form>
+    <button id="submitNames">Tiếp tục</button>
+  </div>
+
+  <div id="step3" class="step hidden">
+    <h2>Nhập role</h2>
+    <form id="roleForm"></form>
+    <button id="startGame">Bắt đầu</button>
+  </div>
+
+  <div id="step4" class="step hidden">
+    <h2 id="currentPlayer"></h2>
+    <div id="wheelContainer">
+      <div id="wheel"></div>
+      <div id="pointer"></div>
+    </div>
+    <button id="spin">Quay</button>
+    <div id="result"></div>
+    <button id="next" class="hidden">OK</button>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,118 @@
+const playerCountSelect = document.getElementById('playerCount');
+for (let i = 1; i <= 30; i++) {
+  const opt = document.createElement('option');
+  opt.value = i;
+  opt.textContent = i;
+  playerCountSelect.appendChild(opt);
+}
+
+const step1 = document.getElementById('step1');
+const step2 = document.getElementById('step2');
+const step3 = document.getElementById('step3');
+const step4 = document.getElementById('step4');
+
+const startNames = document.getElementById('startNames');
+const submitNames = document.getElementById('submitNames');
+const startGameBtn = document.getElementById('startGame');
+const spinBtn = document.getElementById('spin');
+const nextBtn = document.getElementById('next');
+
+let numPlayers = 0;
+let players = [];
+let roles = [];
+let remainingRoles = [];
+let currentPlayer = 0;
+
+startNames.addEventListener('click', () => {
+  numPlayers = parseInt(playerCountSelect.value);
+  const nameForm = document.getElementById('nameForm');
+  nameForm.innerHTML = '';
+  for (let i = 0; i < numPlayers; i++) {
+    const input = document.createElement('input');
+    input.placeholder = `Người chơi ${i + 1}`;
+    nameForm.appendChild(input);
+  }
+  showStep(2);
+});
+
+submitNames.addEventListener('click', () => {
+  const inputs = document.querySelectorAll('#nameForm input');
+  players = [];
+  inputs.forEach((inp, idx) => {
+    players.push(inp.value || `Người chơi ${idx + 1}`);
+  });
+  const roleForm = document.getElementById('roleForm');
+  roleForm.innerHTML = '';
+  for (let i = 0; i < numPlayers; i++) {
+    const input = document.createElement('input');
+    input.placeholder = `Role ${i + 1}`;
+    roleForm.appendChild(input);
+  }
+  showStep(3);
+});
+
+startGameBtn.addEventListener('click', () => {
+  const inputs = document.querySelectorAll('#roleForm input');
+  roles = [];
+  inputs.forEach((inp, idx) => {
+    roles.push(inp.value || `Role ${idx + 1}`);
+  });
+  remainingRoles = roles.slice();
+  currentPlayer = 0;
+  showStep(4);
+  setupPlayer();
+});
+
+function showStep(n) {
+  [step1, step2, step3, step4].forEach((s, i) => s.classList.toggle('hidden', i !== n - 1));
+}
+
+function setupPlayer() {
+  document.getElementById('currentPlayer').textContent = players[currentPlayer];
+  document.getElementById('result').textContent = '';
+  nextBtn.classList.add('hidden');
+  spinBtn.disabled = false;
+  updateWheel();
+  const wheel = document.getElementById('wheel');
+  wheel.style.transition = 'none';
+  wheel.style.transform = 'rotate(0deg)';
+}
+
+function updateWheel() {
+  const wheel = document.getElementById('wheel');
+  const n = remainingRoles.length;
+  const step = 360 / n;
+  const colors = [];
+  for (let i = 0; i < n; i++) {
+    colors.push(`hsl(${(i * step) % 360},70%,60%) ${i * step}deg ${(i + 1) * step}deg`);
+  }
+  wheel.style.background = `conic-gradient(${colors.join(',')})`;
+}
+
+spinBtn.addEventListener('click', () => {
+  if (remainingRoles.length === 0) return;
+  const wheel = document.getElementById('wheel');
+  const n = remainingRoles.length;
+  const index = Math.floor(Math.random() * n);
+  const selected = remainingRoles.splice(index, 1)[0];
+  const spinDeg = 360 * 4 + Math.random() * 360;
+  wheel.style.transition = 'transform 4s ease-out';
+  wheel.style.transform = `rotate(${spinDeg}deg)`;
+  spinBtn.disabled = true;
+  setTimeout(() => {
+    document.getElementById('result').textContent = `${players[currentPlayer]} - ${selected}`;
+    nextBtn.classList.remove('hidden');
+  }, 4000);
+});
+
+nextBtn.addEventListener('click', () => {
+  currentPlayer++;
+  if (currentPlayer < players.length) {
+    setupPlayer();
+  } else {
+    document.getElementById('currentPlayer').textContent = 'Hoàn thành!';
+    document.getElementById('wheelContainer').classList.add('hidden');
+    spinBtn.classList.add('hidden');
+    nextBtn.classList.add('hidden');
+  }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,56 @@
+body {
+  font-family: Arial, sans-serif;
+  text-align: center;
+  margin: 20px;
+}
+
+.step {
+  margin-top: 20px;
+}
+
+.hidden {
+  display: none;
+}
+
+form input {
+  display: block;
+  margin: 5px auto;
+}
+
+#wheelContainer {
+  position: relative;
+  margin: 20px auto;
+  width: 300px;
+  height: 300px;
+}
+
+#wheel {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  border: 2px solid #333;
+  background: #ddd;
+  transition: transform 4s ease-out;
+}
+
+#pointer {
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-bottom: 20px solid red;
+}
+
+#spin {
+  margin-top: 20px;
+}
+
+#result {
+  margin-top: 20px;
+  font-size: 1.2em;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- Build interactive HTML/CSS/JS app to assign random roles to up to 30 players via spinning wheel
- Allow entering player names and roles before spinning

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689f575a601883209c9dd4c215976294